### PR TITLE
fix: Add ZksyncMiddleware to get bytecode

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,8 @@ pub enum DatabaseError {
     BlockNotFound(BlockId),
     #[error("failed to get transaction {0}: {1}")]
     GetTransaction(B256, Arc<eyre::Error>),
+    #[error("failed to get bytecode for {0:?}: {1}")]
+    GetBytecode(B256, Arc<eyre::Error>),
 }
 
 impl DatabaseError {
@@ -43,6 +45,7 @@ impl DatabaseError {
             Self::GetTransaction(_, err) => Some(err),
             // Enumerate explicitly to make sure errors are updated if a new one is added.
             Self::MissingCode(_) | Self::Recv(_) | Self::Send(_) | Self::BlockNotFound(_) => None,
+            Self::GetBytecode(_, err) => Some(err),
         }
     }
 


### PR DESCRIPTION
## Solution
Added the middleware trait and implementation to get btyecodes. Also added the error type for this case
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
